### PR TITLE
Fixing single workspace recommendation.

### DIFF
--- a/checklists/lz_checklist.en.json
+++ b/checklists/lz_checklist.en.json
@@ -883,18 +883,10 @@
     {
       "category": "Management",
       "subcategory": "Monitoring",
-      "text": "Use a single monitor logs workspace to manage platforms centrally except where Azure role-based access control (Azure RBAC)",
+      "text": "Use a single monitor logs workspace to manage platforms centrally except where Azure role-based access control (Azure RBAC), data sovereignty requirements, or data retention policies mandate separate workspaces.",
       "severity": "Medium",
       "training": "&nbsp",
-      "link": "https://docs.microsoft.com/azure/private-link/inspect-traffic-with-azure-firewall"
-    },
-    {
-      "category": "Management",
-      "subcategory": "Monitoring",
-      "text": "Data sovereignty requirements and data retention policies mandate separate workspaces",
-      "severity": "Medium",
-      "training": "&nbsp",
-      "link": "&nbsp"
+      "link": "https://docs.microsoft.com/en-us/azure/azure-monitor/logs/design-logs-deployment"
     },
     {
       "category": "Management",


### PR DESCRIPTION
Fixing a minor issue whereby a recommendation to use a single workspace unless RBAC, data sovereignty, or data retention requirements suggest otherwise was wrongly split across two lines.
Also updated the associated documentation link to point to a relevant article instead of Azure Firewall documentation.