### PR TITLE
node image upgrade

### DIFF
--- a/checklists/aks_checklist.en.json
+++ b/checklists/aks_checklist.en.json
@@ -467,10 +467,18 @@
     {
       "category": "Operations",
       "subcategory": "Compliance",
-      "text": "Use kured for Linux node upgrades",
+      "text": "Use kured for Linux node upgrades in case you are not using node-image upgrade",
       "guid": "6f7c4c0d-4e51-4464-ad24-57ed67138b82",
       "severity": "High",
       "link": "https://docs.microsoft.com/azure/aks/node-updates-kured"
+    },
+    {
+      "category": "Operations",
+      "subcategory": "Compliance",
+      "text": "Have a regular process to upgrade the cluster node images periodically (weekly, for example)",
+      "guid": "6f7c4c0d-4e51-4464-ad24-57ed67138b82",
+      "severity": "High",
+      "link": "https://docs.microsoft.com/en-us/azure/aks/node-image-upgrade"
     },
     {
       "category": "Operations",

--- a/checklists/aks_checklist.en.json
+++ b/checklists/aks_checklist.en.json
@@ -476,7 +476,7 @@
       "category": "Operations",
       "subcategory": "Compliance",
       "text": "Have a regular process to upgrade the cluster node images periodically (weekly, for example)",
-      "guid": "6f7c4c0d-4e51-4464-ad24-57ed67138b82",
+      "guid": "139c9580-ade3-426a-ba09-cf157d9f6477",
       "severity": "High",
       "link": "https://docs.microsoft.com/en-us/azure/aks/node-image-upgrade"
     },

--- a/checklists/aks_checklist.en.json
+++ b/checklists/aks_checklist.en.json
@@ -459,7 +459,7 @@
     {
       "category": "Operations",
       "subcategory": "Compliance",
-      "text": "Have a regular process to upgrade the cluster periodically (quarterly, for example)",
+      "text": "Have a regular process to upgrade your kubernetes version periodically (quarterly, for example), or use the AKS autoupgrade feature",
       "guid": "e189c599-df0d-45a7-9dd4-ce32c1881370",
       "severity": "High",
       "link": "https://docs.microsoft.com/azure/aks/supported-kubernetes-versions"

--- a/checklists/aks_checklist.en.json
+++ b/checklists/aks_checklist.en.json
@@ -582,6 +582,14 @@
     },
     {
       "category": "Operations",
+      "subcategory": "Monitoring",
+      "text": "Subscribe to resource health notifications for your AKS cluster",
+      "guid": "74c2ee76-569b-4a79-a57e-dedf91b022c9",
+      "severity": "Medium",
+      "link": "https://docs.microsoft.com/en-us/azure/aks/aks-resource-health"
+    },
+    {
+      "category": "Operations",
       "subcategory": "Compliance",
       "text": "Send master logs (aka API logs) to Log Analytics",
       "guid": "5b56ad48-408f-4e72-934c-476ba280dcf5",

--- a/checklists/aks_checklist.en.json
+++ b/checklists/aks_checklist.en.json
@@ -478,7 +478,7 @@
       "text": "Have a regular process to upgrade the cluster node images periodically (weekly, for example)",
       "guid": "139c9580-ade3-426a-ba09-cf157d9f6477",
       "severity": "High",
-      "link": "https://docs.microsoft.com/en-us/azure/aks/node-image-upgrade"
+      "link": "https://docs.microsoft.com/azure/aks/node-image-upgrade"
     },
     {
       "category": "Operations",
@@ -586,7 +586,7 @@
       "text": "Subscribe to resource health notifications for your AKS cluster",
       "guid": "74c2ee76-569b-4a79-a57e-dedf91b022c9",
       "severity": "Medium",
-      "link": "https://docs.microsoft.com/en-us/azure/aks/aks-resource-health"
+      "link": "https://docs.microsoft.com/azure/aks/aks-resource-health"
     },
     {
       "category": "Operations",


### PR DESCRIPTION
node image upgrade is now a better way of upgrading your node images on AKS. Adding this to the checklist. 
Wasn't sure on the current kured guidance whether it should stay in the list, as in, customer should have a choice, right? 