### PR TITLE
Changed the link for custom roles to ESLZ pages

### DIFF
--- a/checklists/lz_checklist.en.json
+++ b/checklists/lz_checklist.en.json
@@ -78,8 +78,8 @@
       "text": "If the following roles are considered, use Azure custom roles: Azure platform owner, network management, security operations, subscription owner, application owner",
       "guid": "f5664b5e-984a-4859-a773-e7d261623a76",
       "severity": "Medium",
-      "training": "https://docs.microsoft.com/en-gb/learn/modules/create-custom-azure-roles-with-rbac/",
-      "link": "https://docs.microsoft.com/azure/role-based-access-control/custom-roles"
+      "training": "https://docs.microsoft.com/learn/modules/create-custom-azure-roles-with-rbac/",
+      "link": "https://docs.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/identity-access#prerequisites-for-a-landing-zone---design-recommendations"
     },
     {
       "category": "Identity and Access",


### PR DESCRIPTION
I think this link is more appropriate to understand what those roles actually do, and why they might be required