### PR TITLE
add taint to system nodepool

### DIFF
--- a/checklists/aks_checklist.en.json
+++ b/checklists/aks_checklist.en.json
@@ -369,10 +369,10 @@
     {
       "category": "Governance and Security",
       "subcategory": "Compliance",
-      "text": "Label your system nodepool to use it with node selectors",
+      "text": "Add taint to your system nodepool to make it dedicated",
       "guid": "a7a1f893-9bda-4477-98f2-4c116775c2ea",
       "severity": "Low",
-      "link": "https://docs.microsoft.com/azure/aks/use-multiple-node-pools"
+      "link": "https://docs.microsoft.com/en-us/azure/aks/use-system-pools"
     },
     {
       "category": "Governance and Security",

--- a/checklists/aks_checklist.en.json
+++ b/checklists/aks_checklist.en.json
@@ -372,7 +372,7 @@
       "text": "Add taint to your system nodepool to make it dedicated",
       "guid": "a7a1f893-9bda-4477-98f2-4c116775c2ea",
       "severity": "Low",
-      "link": "https://docs.microsoft.com/en-us/azure/aks/use-system-pools"
+      "link": "https://docs.microsoft.com/azure/aks/use-system-pools"
     },
     {
       "category": "Governance and Security",


### PR DESCRIPTION
It doesn't make sense to use labels and node selectors to schedule user pods to system node pool. Rather, a right taint should be add to the system node pool to make it dedicated for system pods. 