### PR TITLE
Consistent status section in all checklists

### DIFF
--- a/checklists/aks_checklist.en.json
+++ b/checklists/aks_checklist.en.json
@@ -828,11 +828,11 @@
     },
     {
       "name": "Not required",
-      "description": "Not applicable for current design"
+      "description": "Not required"
     },
     {
       "name": "N/A",
-      "description": "Not required"
+      "description": "Not applicable for current design"
     }
   ],
   "severities": [

--- a/checklists/avd_checklist.en.json
+++ b/checklists/avd_checklist.en.json
@@ -1028,16 +1028,24 @@
   ],
   "status": [
     {
-      "name": "Not verified"
+      "name": "Not verified",
+      "description": "This check has not been looked at yet"
     },
     {
-      "name": "Open"
+      "name": "Open",
+      "description": "There is an action item associated to this check"
     },
     {
-      "name": "Fulfilled"
+      "name": "Fulfilled",
+      "description": "This check has been verified, and there are no further action items associated to it"
     },
     {
-      "name": "N/A"
+      "name": "Not required",
+      "description": "Not required"
+    },
+    {
+      "name": "N/A",
+      "description": "Not applicable for current design"
     }
   ],
   "severities": [

--- a/checklists/avs_checklist.en.json
+++ b/checklists/avs_checklist.en.json
@@ -647,16 +647,24 @@
   ],
   "status": [
     {
-      "name": "Not verified"
+      "name": "Not verified",
+      "description": "This check has not been looked at yet"
     },
     {
-      "name": "Open"
+      "name": "Open",
+      "description": "There is an action item associated to this check"
     },
     {
-      "name": "Fulfilled"
+      "name": "Fulfilled",
+      "description": "This check has been verified, and there are no further action items associated to it"
     },
     {
-      "name": "N/A"
+      "name": "Not required",
+      "description": "Not required"
+    },
+    {
+      "name": "N/A",
+      "description": "Not applicable for current design"
     }
   ],
   "severities": [

--- a/checklists/lz_checklist.en.json
+++ b/checklists/lz_checklist.en.json
@@ -1433,6 +1433,10 @@
       "description": "This check has been verified, and there are no further action items associated to it"
     },
     {
+      "name": "Not required",
+      "description": "Not required"
+    },
+    {
       "name": "N/A",
       "description": "Not applicable for current design"
     }

--- a/checklists/security_checklist.en.json
+++ b/checklists/security_checklist.en.json
@@ -1291,16 +1291,24 @@
   ],
   "status": [
     {
-      "name": "Not verified"
+      "name": "Not verified",
+      "description": "This check has not been looked at yet"
     },
     {
-      "name": "Open"
+      "name": "Open",
+      "description": "There is an action item associated to this check"
     },
     {
-      "name": "Fulfilled"
+      "name": "Fulfilled",
+      "description": "This check has been verified, and there are no further action items associated to it"
     },
     {
-      "name": "N/A"
+      "name": "Not required",
+      "description": "Not required"
+    },
+    {
+      "name": "N/A",
+      "description": "Not applicable for current design"
     }
   ],
   "severities": [


### PR DESCRIPTION
The 'status' sections across the spreadsheets are inconsistent. The AKS checklist has the following status options: Not verified, Open, Fulfilled, Not required, N/A. All other checklists have the same options except for 'Not required'. 

This PR aligns all checklists to use the same status options and they include the same description. This also fixes a typo in the AKS checklist where the description of 'Not required' and 'N/A' we're reversed. 

This is related to this issue #158 