### PR TITLE
Update lz_checklist.en.json

### DIFF
--- a/checklists/lz_checklist.en.json
+++ b/checklists/lz_checklist.en.json
@@ -863,6 +863,15 @@
     },
     {
       "category": "Network Topology and Connectivity",
+      "subcategory": "App delivery",
+      "text": "If users only need access to internal applications, has Azure AD Application Proxy been considered as an alternative to Azure Virtual Desktop (AVD)?",
+      "guid": "3b4b3e88-a459-4ed5-a22f-644dfbc58204",
+      "severity": "Low",
+      "training": "https://docs.microsoft.com/en-us/learn/modules/configure-azure-ad-application-proxy/",
+      "link": "https://docs.microsoft.com/en-us/azure/active-directory/app-proxy/application-proxy#how-application-proxy-works"
+    },
+    {
+      "category": "Network Topology and Connectivity",
       "subcategory": "Segmentation",
       "text": "Delegate subnet creation to the landing zone owner. ",
       "guid": "c2447ec6-6138-4a72-80f1-ce16ed301d6e",


### PR DESCRIPTION
Suggesting the addition of a recommendation to consider Azure AD App Proxy as a potential alternative to AVD, if users only need access to internal apps. Could be a relevant conversation if the customer is thinking of going with an AVD deployment as part of their migration. 

We initially thought this could be added to the AVD checklist, but later realized it may not a be a good fit (if we're doing an AVD review, the customer has most likely already made their decision).