### PR TITLE
adding Simona K as an owner for security checklist

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,7 +33,7 @@
 /checklists/aks_checklist.en.json @erjosito @seenu433 @msftnadavbh
 /checklists/avd_checklist.en.json @igorpag @mikewarr @bagwyth
 /checklists/avs_checklist.en.json @fskelly @mgodfrey50 @Kiwibayer @robinher
-/checklists/security_checklist.en.json @mgodfrey50 @rudneir2
+/checklists/security_checklist.en.json @mgodfrey50 @rudneir2 @sikovatc
 /checklists/sap_checklist.en.json @AlastairMorrison @videshmukh
 /checklists/multitenancy_checklist.en.json @arsenvlad @johndowns @cherchyk
 /scripts/ @fskelly @erjosito


### PR DESCRIPTION
As per suggestion from the team this week...  I would like to have a 3rd owner on security checklist for better coverage.

+ @sikovatc 