### PR TITLE
use of Microsoft Accounts - updated more info link

### DIFF
--- a/checklists/lz_checklist.en.json
+++ b/checklists/lz_checklist.en.json
@@ -61,7 +61,7 @@
       "guid": "12e7f983-f630-4472-8dd6-9c5b5c2622f5",
       "severity": "High",
       "training": "https://docs.microsoft.com/learn/modules/explore-basic-services-identity-types/",
-      "link": "https://docs.microsoft.com/en-us/azure/active-directory/roles/security-planning#identify-microsoft-accounts-in-administrative-roles-that-need-to-be-switched-to-work-or-school-accounts"
+      "link": "https://docs.microsoft.com/azure/active-directory/roles/security-planning#identify-microsoft-accounts-in-administrative-roles-that-need-to-be-switched-to-work-or-school-accounts"
     },
     {
       "category": "Identity and Access",

--- a/checklists/lz_checklist.en.json
+++ b/checklists/lz_checklist.en.json
@@ -61,7 +61,7 @@
       "guid": "12e7f983-f630-4472-8dd6-9c5b5c2622f5",
       "severity": "High",
       "training": "https://docs.microsoft.com/learn/modules/explore-basic-services-identity-types/",
-      "link": "https://docs.microsoft.com/azure/active-directory-b2c/user-overview"
+      "link": "https://docs.microsoft.com/en-us/azure/active-directory/roles/security-planning#identify-microsoft-accounts-in-administrative-roles-that-need-to-be-switched-to-work-or-school-accounts"
     },
     {
       "category": "Identity and Access",


### PR DESCRIPTION
The existing more info link refers to Azure AD B2C identity types, which is not the correct documentation for this. The updated link directs partners to role security planning for Azure AD doc. 

/cc @mbrat2005 @SRINI-THUMALA 