### PR TITLE
Updating Link.

### DIFF
--- a/checklists/lz_checklist.en.json
+++ b/checklists/lz_checklist.en.json
@@ -591,7 +591,7 @@
       "guid": "c2299c4d-7b57-4d0c-9555-62f2b3e4563a",
       "severity": "Medium",
       "training": "https://docs.microsoft.com/learn/modules/design-implement-azure-expressroute/",
-      "link": "https://docs.microsoft.com/azure/expressroute/expressroute-routing"
+      "link": "https://learn.microsoft.com/en-us/azure/expressroute/about-fastpath"
     },
     {
       "category": "Network Topology and Connectivity",


### PR DESCRIPTION
Given that FastPath has specific requirements like GW size and some of the features like vnet peeting/private link support are still in preview, adding the link to the actual doc would perhaps make it more clear.