### PR TITLE
Minor wording

### DIFF
--- a/checklists/lz_checklist.en.json
+++ b/checklists/lz_checklist.en.json
@@ -1149,7 +1149,7 @@
     {
       "category": "Management and Monitoring",
       "subcategory": "Monitoring",
-      "text": "Employ Azure Site Recovery for Azure-to-Azure Virtual Machines disaster recovery scenarios. This enables you to replicate workloads across regions.",
+      "text": "Use Azure Site Recovery for Azure-to-Azure Virtual Machines disaster recovery scenarios. This enables you to replicate workloads across regions.",
       "guid": "2476e49f-541a-4cdc-b979-377bcdb3751a",
       "severity": "Medium",
       "link": "https://docs.microsoft.com/azure/site-recovery/site-recovery-overview"


### PR DESCRIPTION
The word "employ" (Employ Azure Site Recovery for Azure-to-Azure Virtual Machines disaster recovery scenarios) was confusing to my customer. Can we use "use" instead :)