### PR TITLE
Query corrections

### DIFF
--- a/checklists/lz_checklist.en.json
+++ b/checklists/lz_checklist.en.json
@@ -141,7 +141,7 @@
             "text": "Enforce reasonably flat management group hierarchy with no more than three to four levels, ideally",
             "guid": "2df27ee4-12e7-4f98-9f63-04722dd69c5b",
             "severity": "Medium",
-            "graph": "resourcecontainers| where type == 'microsoft.resources/subscriptions'| extend ManagementGroup = tostring(tags),mgmtChain = properties.managementGroupAncestorsChain| extend compliant =( array_length(mgmtChain) < 4 and array_length(mgmtChain) > 1)",
+            "graph": "resourcecontainers| where type == 'microsoft.resources/subscriptions'| extend ManagementGroup = tostring(tags),mgmtChain = properties.managementGroupAncestorsChain| extend compliant =( array_length(mgmtChain) <= 4 and array_length(mgmtChain) > 1)",
             "training": "https://docs.microsoft.com/learn/modules/azure-architecture-fundamentals/",
             "link": "https://docs.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups"
         },

--- a/checklists/lz_checklist.en.json
+++ b/checklists/lz_checklist.en.json
@@ -818,7 +818,7 @@
             "text": "Ensure that IP address space isn't wasted, don't create unnecessarily large virtual networks (for example /16) ",
             "guid": "33aad5e8-c68e-41d7-9667-313b4f5664b5",
             "severity": "Medium",
-            "graph": "resources | where type == 'microsoft.network/virtualnetworks' | extend addressSpace = todynamic(properties.addressSpace) | extend addressPrefix = todynamic(properties.addressSpace.addressPrefixes) | mvexpand addressSpace | mvexpand addressPrefix | extend addressMask = split(addressPrefix,'/')[1] | extend compliant = addressMask >= 16 | project name, id, subscriptionId, resourceGroup, addressPrefix, compliant",
+            "graph": "resources | where type == 'microsoft.network/virtualnetworks' | extend addressSpace = todynamic(properties.addressSpace) | extend addressPrefix = todynamic(properties.addressSpace.addressPrefixes) | mvexpand addressSpace | mvexpand addressPrefix | extend addressMask = split(addressPrefix,'/')[1] | extend compliant = addressMask > 16 | project name, id, subscriptionId, resourceGroup, addressPrefix, compliant",
             "training": "https://docs.microsoft.com/learn/paths/architect-network-infrastructure/",
             "link": "https://docs.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/plan-for-ip-addressing"
         },


### PR DESCRIPTION
Some typos in the Resource Graph query code makes resources show up as non-compliant even though they should be compliant and vice versa.

It's regrading these two recommendations:
"Enforce reasonably flat management group hierarchy with no more than three to four levels, ideally"
Subscriptions in Corp and Online management groups in the Azure Landing Zones architectural guidance shows as non-complaint even though they are four levels which should be allowed according to the description.

"Ensure that IP address space isn't wasted, don't create unnecessarily large virtual networks (for example /16)"
Virtual Networks with a /16 mask shows as compliant even though the description states /16 as not recommended.
