### PR TITLE
Update recommendation on preventing resource provider registrations

### DIFF
--- a/checklists/lz_checklist.en.json
+++ b/checklists/lz_checklist.en.json
@@ -1409,10 +1409,10 @@
         {
             "category": "Security, Governance and Compliance",
             "subcategory": "Governance",
-            "text": "Use Azure Policy to control resource provider registrations at the subscription and/or management group levels",
+            "text": "Use Azure Policy to control which services users can provision at the subscription/management group level",
             "guid": "43334f24-9116-4341-a2ba-527526944008",
             "severity": "Low",
-            "link": "https://learn.microsoft.com/azure/governance/policy/overview"
+            "link": "https://learn.microsoft.com/security/benchmark/azure/mcsb-asset-management#am-2-use-only-approved-services"
         },
         {
             "category": "Security, Governance and Compliance",


### PR DESCRIPTION
Recently it was pointed out that there is no built-in policy definition that could be used to prevent resource provider registrations. To provide a similar, mitigating control against unauthorized services being used I have updated the recommendation. Instead, environments should have the "[allowed resource types](https://portal.azure.com/#blade/Microsoft_Azure_Policy/PolicyDetailBlade/definitionId/%2Fproviders%2FMicrosoft.Authorization%2FpolicyDefinitions%2Fa08ec900-254a-4555-9bf5-e42af04b5c5c)" built-in policy assigned at scopes which need this restriction.