### PR TITLE
partner/customer wording removed

### DIFF
--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -516,7 +516,7 @@
         {
             "category": "Management and Monitoring",
             "subcategory": "Monitoring",
-            "text": "Use Azure-native backup capabilities. Verify that partner/customer is aware of Azure Backup and all new capabilities which greatly can simplify backup management",
+            "text": "Use Azure-native backup capabilities, or an Azure-compatible, 3rd-party backup solution.",
             "waf": "Operations",
             "guid": "f625ca44-e569-45f2-823a-ce8cb12308ca",
             "severity": "Medium",


### PR DESCRIPTION
The wording was good for the time when the checklist was solely used by FTA engineers, with self-service we should remove these expressions.