### PR TITLE
Remove check about FQDN filtering when using vnet svc endpoints

### DIFF
--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1476,6 +1476,16 @@
         },
         {
             "category": "Network Topology and Connectivity",
+            "subcategory": "PaaS",
+            "text": "Filter egress FQDNs of PaaS resources on Azure Firewall or an NVA to prevent data exfiltration. If using private link, you can block all public endpoints for a resource type. For public endpoints, allow only those endpoints used in your organization.",
+            "waf": "Security",
+            "guid": "7e7a8ed4-b30e-438c-9f29-812b2363cefe",
+            "severity": "Medium",
+            "training": "https://learn.microsoft.com/learn/paths/implement-network-security/?source=learn",
+            "link": "https://learn.microsoft.com/azure/app-service/networking-features"
+        },
+        {
+            "category": "Network Topology and Connectivity",
             "subcategory": "Segmentation",
             "text": "Use a /26 prefix for your Azure Firewall subnets.",
             "waf": "Security",

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1476,16 +1476,6 @@
         },
         {
             "category": "Network Topology and Connectivity",
-            "subcategory": "PaaS",
-            "text": "If using virtual network service endpoints, filter egress FQDNs on an NVA to prevent data exfiltration.",
-            "waf": "Security",
-            "guid": "7e7a8ed4-b30e-438c-9f29-812b2363cefe",
-            "severity": "Medium",
-            "training": "https://learn.microsoft.com/learn/paths/implement-network-security/?source=learn",
-            "link": "https://learn.microsoft.com/azure/app-service/networking-features"
-        },
-        {
-            "category": "Network Topology and Connectivity",
             "subcategory": "Segmentation",
             "text": "Use a /26 prefix for your Azure Firewall subnets.",
             "waf": "Security",


### PR DESCRIPTION
That check is confusing for multiple reasons:
- First of all, the recommendation is using private link to prevent data exfiltration, people shouldnt be using service endpoints
- Second, the check is factually wrong, because when using service endpoints, Azure routing will force traffic to bypass any NVA or firewall