### PR TITLE
Modified a text of the review item related to the requirement of having more than 5000 nodes

### DIFF
--- a/checklists/aks_checklist.en.json
+++ b/checklists/aks_checklist.en.json
@@ -1209,7 +1209,7 @@
         {
             "category": "Operations",
             "subcategory": "Scalability",
-            "text": "If required for scalability consider adding more than 5000 nodes",
+            "text": "If more than 5000 nodes are required for scalability then consider using an additional AKS cluster",
             "waf": "Performance",
             "guid": "38800e6a-ae01-40a2-9fbc-ae5a06e5462d",
             "id": "07.06.05",


### PR DESCRIPTION
A single AKS cluster cannot have more than 5000 nodes. So modified the text of the review item as below:

Older text - If required for scalability consider adding more than 5000 nodes
Proposed text - If more than 5000 nodes are required for scalability then consider using an additional AKS cluster