### PR TITLE
Add support for Chinese Traditional (zh-Hant)

### DIFF
--- a/scripts/translate.py
+++ b/scripts/translate.py
@@ -7,7 +7,7 @@ import uuid
 
 # Variables
 translate_keys = ('description', 'name', 'category', 'subcategory', 'waf', 'text', 'severity')
-translate_languages = ['es', 'ja', 'pt', 'ko']
+translate_languages = ['es', 'ja', 'pt', 'ko', 'zh-Hant']
 
 # Get environment variables
 translator_endpoint = os.environ["AZURE_TRANSLATOR_ENDPOINT"]


### PR DESCRIPTION
To speed up the implementation of Azure technologies, as a significant number of local government and financial customers are only familiar with the Chinese Traditional (zh-Hant) language, suggest to support the language here.

Ref: https://learn.microsoft.com/en-us/azure/ai-services/translator/language-support