### PR TITLE
bug? - path to checklist_list

### DIFF
--- a/scripts/checklist_graph.sh
+++ b/scripts/checklist_graph.sh
@@ -131,7 +131,7 @@ fi
 if [[ "$list_technologies" == "yes" ]]
 then
     # Get list of checklists
-    checklist_list=$(curl -s "https://api.github.com/repos/Azure/review-checklists/git/trees/2ef1d5ca7dbdc4a3125901ab1364be0338f390a1?recursive=true" | jq -r '.tree[].path' | grep en.json | sed -e 's/_checklist.en.json//')
+    checklist_list=$(curl -s "https://api.github.com/repos/Azure/review-checklists/git/trees/31f9cd483a40767ac9bd7195214ece13bd36fecf?recursive=true" | jq -r '.tree[].path' | grep en.json | sed -e 's/_checklist.en.json//')
     while IFS= read -r checklist; do
         checklist_url="${base_url}${checklist}_checklist.en.json"
         if [[ "$debug" == "yes" ]]; then echo "DEBUG: Processing JSON content from URL $checklist_url..."; fi


### PR DESCRIPTION
I might well be missing some key piece of information, but there is a parse error when you run ``./checklist_graph.sh --list-technologies``:

```
parse error: Expected string key before ':' at line 1, column 4
lz (0 graph queries)
```

This seems because it is referencing a previous tree path in the API (see commit diff).

With this suggested PR, it correctly finds the 'alz' and the graph queries:

```
/review-checklists/scripts$ ./checklist_graph.sh --list-technologies
acr_security (0 graph queries)
ado (0 graph queries)
aks (24 graph queries)
alz (28 graph queries)
<snip>
```

& with this, the queries execute as well via ``./checklist_graph.sh --technology=alz``.

```
DEBUG: Output is , setting --check-text=no and --no-empty=yes...
DEBUG: Getting checklist from https://raw.githubusercontent.com/Azure/review-checklists/main/checklists/alz_checklist.en.json...
<snip, etc>
```

Is this something that is remedied before tagging, or a bug?