### PR TITLE
Updated translate workflow for Issue #436

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -48,7 +48,7 @@ jobs:
       #   wouldn't be run, not setting the variable `done_something`, so that the rest of
       #   the steps are not executed either.
       - name: Work with the list of modified files - sort, update timestamp, translate
-        if: ${{ steps.automationresult.outputs.excel_file_changed }} != 'yes'
+        if: ${{ steps.automationresult.outputs.excel_file_changed != 'yes' }}
         id: translate
         env:
           AZURE_TRANSLATOR_SUBSCRIPTION_KEY: ${{ secrets.AZURE_TRANSLATOR_SUBSCRIPTION_KEY }}


### PR DESCRIPTION
Hi team,
This PR is introduced by Issue #436.
 I checked https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif and compared conditionals on steps. This made me realize they only include the variable between <kdb>${{</kdb> and <kdb>}}</kdb>, but not the whole conditional as advised on documentation. 

I am not sure if this is to be merged on a dev branch instead of main. If so, please, let me know.
Regards.