### PR TITLE
Update and review links in check list

### DIFF
--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1269,7 +1269,7 @@
             "id": "D07.03",
             "severity": "Low",
             "training": "https://learn.microsoft.com/learn/paths/secure-networking-infrastructure/",
-            "link": "https://learn.microsoft.com/azure/firewall/"
+            "link": "https://learn.microsoft.com/en-us/azure/firewall-manager/deploy-trusted-security-partner"
         },
         {
             "category": "Network Topology and Connectivity",

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -52,7 +52,7 @@
             "guid": "a24d0de3-d4b9-4dfb-8ddd-bbfaf123fa01",
             "id": "A02.02",
             "severity": "Low",
-            "link": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/azure-billing-microsoft-customer-agreement#design-recommendations"
+            "link": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/azure-billing-cloud-solution-provider#design-recommendations"
         },
         {
             "category": "Azure Billing and Microsoft Entra ID Tenants",

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1879,7 +1879,7 @@
             "guid": "78b22132-b41c-460b-a4d3-df8f73a67dc2",
             "id": "E01.11",
             "severity": "Medium",
-            "link": "https://github.com/Azure/sovereign-landing-zone/blob/main/docs/scenarios/Sovereignty-Policy-Baseline.md"
+            "link": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/sovereign-landing-zone"
         },
         {
             "category": "Governance",

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1868,7 +1868,7 @@
             "id": "E01.10",
             "severity": "Medium",
             "training": "https://learn.microsoft.com/learn/paths/secure-your-cloud-data/",
-            "link": "https://azure.microsoft.com/resources/achieving-compliant-data-residency-and-security-with-azure/"
+            "link": "https://learn.microsoft.com/en-us/industry/release-plan/2023wave2/cloud-sovereignty/enable-data-sovereignty-policy-baseline"
         },
         {
             "category": "Governance",

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1494,7 +1494,7 @@
             "guid": "64e7000e-3c06-485e-b455-ced7f454cba3",
             "id": "D07.21",
             "severity": "Low",
-            "link": " https://learn.microsoft.com/azure/well-architected/service-guides/azure-firewall"
+            "link": "https://learn.microsoft.com/azure/well-architected/service-guides/azure-firewall"
         },
         {
             "category": "Network Topology and Connectivity",

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1257,7 +1257,7 @@
             "id": "D07.02",
             "severity": "Medium",
             "training": "https://learn.microsoft.com/learn/paths/secure-networking-infrastructure/",
-            "link": "https://learn.microsoft.com/azure/firewall/"
+            "link": "https://learn.microsoft.com/en-us/azure/well-architected/service-guides/azure-firewall"
         },
         {
             "category": "Network Topology and Connectivity",

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -2452,7 +2452,7 @@
             "id": "G03.05",
             "ammp": true,
             "severity": "High",
-            "link": "https://www.microsoft.com/en-gb/security/business/solutions/cloud-workload-protection"
+            "link": "https://learn.microsoft.com/azure/defender-for-cloud/connect-azure-subscription"
         },
         {
             "category": "Security",

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1494,7 +1494,7 @@
             "guid": "64e7000e-3c06-485e-b455-ced7f454cba3",
             "id": "D07.21",
             "severity": "Low",
-            "link": "https://techcommunity.microsoft.com/t5/azure-network-security-blog/runbook-to-manage-azure-firewall-back-ups/ba-p/3066035"
+            "link": " https://learn.microsoft.com/azure/well-architected/service-guides/azure-firewall"
         },
         {
             "category": "Network Topology and Connectivity",

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -607,7 +607,7 @@
             "id": "D01.03",
             "severity": "Medium",
             "training": "https://learn.microsoft.com/learn/paths/secure-networking-infrastructure/",
-            "link": "https://learn.microsoft.com/azure/web-application-firewall/ag/ag-overview"
+            "link": "https://learn.microsoft.com/azure/ddos-protection/ddos-protection-overview"
         },
         {
             "category": "Network Topology and Connectivity",

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -838,7 +838,7 @@
             "id": "D04.07",
             "severity": "Medium",
             "training": "https://learn.microsoft.com/learn/modules/design-implement-azure-expressroute/",
-            "link": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/connectivity-to-azure"
+            "link": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/connectivity-to-azure"
         },
         {
             "category": "Network Topology and Connectivity",
@@ -1257,7 +1257,7 @@
             "id": "D07.02",
             "severity": "Medium",
             "training": "https://learn.microsoft.com/learn/paths/secure-networking-infrastructure/",
-            "link": "https://learn.microsoft.com/en-us/azure/well-architected/service-guides/azure-firewall"
+            "link": "https://learn.microsoft.com/azure/well-architected/service-guides/azure-firewall"
         },
         {
             "category": "Network Topology and Connectivity",
@@ -1269,7 +1269,7 @@
             "id": "D07.03",
             "severity": "Low",
             "training": "https://learn.microsoft.com/learn/paths/secure-networking-infrastructure/",
-            "link": "https://learn.microsoft.com/en-us/azure/firewall-manager/deploy-trusted-security-partner"
+            "link": "https://learn.microsoft.com/azure/firewall-manager/deploy-trusted-security-partner"
         },
         {
             "category": "Network Topology and Connectivity",
@@ -1868,7 +1868,7 @@
             "id": "E01.10",
             "severity": "Medium",
             "training": "https://learn.microsoft.com/learn/paths/secure-your-cloud-data/",
-            "link": "https://learn.microsoft.com/en-us/industry/release-plan/2023wave2/cloud-sovereignty/enable-data-sovereignty-policy-baseline"
+            "link": "https://learn.microsoft.com/industry/release-plan/2023wave2/cloud-sovereignty/enable-data-sovereignty-policy-baseline"
         },
         {
             "category": "Governance",
@@ -1879,7 +1879,7 @@
             "guid": "78b22132-b41c-460b-a4d3-df8f73a67dc2",
             "id": "E01.11",
             "severity": "Medium",
-            "link": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/sovereign-landing-zone"
+            "link": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/sovereign-landing-zone"
         },
         {
             "category": "Governance",
@@ -2251,7 +2251,7 @@
             "guid": "01365d38-e43f-49cc-ad86-8266abca264f",
             "id": "G01.02",
             "severity": "Medium",
-            "link": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/security-zero-trust"
+            "link": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/security-zero-trust"
         },
         {
             "category": "Security",

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -2251,7 +2251,7 @@
             "guid": "01365d38-e43f-49cc-ad86-8266abca264f",
             "id": "G01.02",
             "severity": "Medium",
-            "link": "https://www.microsoft.com/security/business/zero-trust"
+            "link": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/security-zero-trust"
         },
         {
             "category": "Security",

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -838,7 +838,7 @@
             "id": "D04.07",
             "severity": "Medium",
             "training": "https://learn.microsoft.com/learn/modules/design-implement-azure-expressroute/",
-            "link": "https://learn.microsoft.com/azure/networking/"
+            "link": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/connectivity-to-azure"
         },
         {
             "category": "Network Topology and Connectivity",


### PR DESCRIPTION
review number 1 (commit: 3755555) to address broken link on E01.11: For Sovereign Landing Zone, sovereignty policy baseline' policy initiative is deployed and and assigned at correct MG level. The replacement link is https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/sovereign-landing-zone.

review number 2 (commit : 311621e) to address link in E01.10: If any data sovereignty requirements exist, Azure Policies can be deployed to enforce them.  The previous link was not a direct link to the recommendation. The new link is https://learn.microsoft.com/en-us/industry/release-plan/2023wave2/cloud-sovereignty/enable-data-sovereignty-policy-baseline

review number 3 ( commit: 15a8417) to address link in G01.02:Implement a zero-trust approach for access to the Azure platform, where appropriate: The previous link was not a direct reference in the landing zone documentation. Since it exist a link in the landing zone documentation, we are better to use that link. the replacement link is  https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/security-zero-trust

review number 4 (commit: 9854008) to address link in D07.03: Configure supported partner SaaS security providers within Firewall Manager if the organization wants to use such solutions to help protect outbound connections. The previous link land at root of Firewall Manager knowledge base. We are better have  link that can reduce search time for delivery engineers. The new link is https://learn.microsoft.com/en-us/azure/firewall-manager/deploy-trusted-security-partner

review number 5 (commit: 183c6be) to address link in D07.02: Create a global Azure Firewall policy to govern security posture across the global network environment and assign it to all Azure Firewall instances. Allow for granular policies to meet requirements of specific regions by delegating incremental firewall policies to local security teams via Azure role-based access control. The previous link land at root of firewall manager knowledge base. we are better have a link that can reduce search time for delivery engineers. The new link has a reference to  a recommendation of using global policy. The new link is https://learn.microsoft.com/en-us/azure/well-architected/service-guides/azure-firewall


review number 6 (commit: 5b52eae) to address link in D04.07: For scenarios that require bandwidth higher than 10 Gbps or dedicated 10/100-Gbps ports, use ExpressRoute Direct. The previous link  land at root of  of the Azure Networking knowledge base. We are better to have a link that can reduce search time for delivery engineers. The new link has a direct reference to the recommendation inside the landing zone documentation. The new link is https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/connectivity-to-azure

review number 7 (commit: dac2eee) to address link in D07.21: Implement backups for your firewall rules. The previous link is using a backup solution that is not align with well architect. The new link contains a reference to the recommendation an there is a companion link that direct engineers to us logic app. The new link is https://learn.microsoft.com/azure/well-architected/service-guides/azure-firewall

review number 8 ( commit: d1be8c6) to address link in G03.05: Enable Defender Cloud Workload Protection Plans for Azure Resources on all subscriptions. The previous link  landed at the root of the documentation of Cloud defender. We are better have a link that will reduce search time for the engineer and land to the documentation that provide directives on how to enable Cloud defender plans for all subscriptions. The new link is https://learn.microsoft.com/azure/defender-for-cloud/connect-azure-subscription

review number 9 ( commit: 16d5bd0) to address link in A02.02: Discuss support request and escalation process with CSP partner. This change is coming from feedback 719157 in Sirona ( feedback tool ). In fact, the previous link is under the customer agreement. We are better to have a link under the cloud solutions provider section with a direct reference to how customer should work with the cloud solutions provider for support request. The new link is https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/azure-billing-cloud-solution-provider#design-recommendations

review number 10 (commit: 0741296) to address link in D01.03: Use a DDoS Network or IP protection plans for all Public IP addresses in application landing zones. This change is coming from feedback 719157 in Sirona ( feedback tool). In fact, the previous link is pointing to the the application gateway technology instead of DDOS.  The new link is https://learn.microsoft.com/azure/ddos-protection/ddos-protection-overview.

