### PR TITLE
Update alz_checklist.en.json

### DIFF
--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1963,7 +1963,7 @@
         {
             "category": "Management",
             "subcategory": "Operational compliance",
-            "text": "Use Azure Update Manager as a patching mechanism for Windows and Linux VMs in outside of Azure using Azure Arc.",
+            "text": "Use Azure Update Manager as a patching mechanism for Windows and Linux VMs outside of Azure using Azure Arc.",
             "waf": "Operations",
             "service": "VM",
             "guid": "c806c048-26b7-4ddf-b4c2-b4f0c476925d",


### PR DESCRIPTION
The entry F01.07 has a typo. This pull request will remove the "in"  that created the typo and the the description will now read like this : Use Azure Update Manager as a patching mechanism for Windows and Linux VMs outside of Azure using Azure Arc.