### PR TITLE
Addressing Resource Organization C02.10

### DIFF
--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -475,7 +475,7 @@
         {
             "category": "Resource Organization",
             "subcategory": "Subscriptions",
-            "text": "Use Reserved Instances where appropriate to optimize cost and ensure available capacity in target regions. Enforce the use of purchased Reserved Instance VM SKUs via Azure Policy.",
+            "text": "Use Reserved Instances where appropriate to optimize cost and ensure available capacity in target regions.",
             "waf": "Security",
             "guid": "c68e1d76-6673-413b-9f56-64b5e984a859",
             "id": "C02.10",


### PR DESCRIPTION
In #707 it is pointed out that C02.10 should not refer to the Azure Policy for reserved instances.  Trimming that section out.