### PR TITLE
Added ARG query for 10.09 in alz_checklist.en.json

### DIFF
--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1837,6 +1837,7 @@
             "guid": "9c75dfef-573c-461c-a698-68598595581a",
             "id": "D10.09",
             "severity": "High",
+            "graph": resources | where type == 'microsoft.network/virtualhubs' | extend addressSpace = properties.addressPrefix | extend compliant= (toint(substring(addressSpace, indexof(addressSpace, "/") + 1)) < 23) | distinct id, compliant,
             "link": "https://learn.microsoft.com/azure/virtual-wan/virtual-wan-faq#what-is-the-recommended-hub-address-space-during-hub-creation",
             "training": "https://learn.microsoft.com/training/modules/introduction-azure-virtual-wan/"
         },

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1837,7 +1837,7 @@
             "guid": "9c75dfef-573c-461c-a698-68598595581a",
             "id": "D10.09",
             "severity": "High",
-            "graph": resources | where type == 'microsoft.network/virtualhubs' | extend addressSpace = properties.addressPrefix | extend compliant= (toint(substring(addressSpace, indexof(addressSpace, "/") + 1)) < 23) | distinct id, compliant,
+            "graph": resources | where type == 'microsoft.network/virtualhubs' | extend addressSpace = (properties.addressPrefix) | extend compliant= (toint(substring(addressSpace, indexof(addressSpace, "/") + 1)) < 23) | distinct id, compliant,
             "link": "https://learn.microsoft.com/azure/virtual-wan/virtual-wan-faq#what-is-the-recommended-hub-address-space-during-hub-creation",
             "training": "https://learn.microsoft.com/training/modules/introduction-azure-virtual-wan/"
         },

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1837,7 +1837,7 @@
             "guid": "9c75dfef-573c-461c-a698-68598595581a",
             "id": "D10.09",
             "severity": "High",
-            "graph": resources | where type == 'microsoft.network/virtualhubs' | extend addressSpace = (properties.addressPrefix) | extend compliant= (toint(substring(addressSpace, indexof(addressSpace, '/') + 1)) < 23) | distinct id, compliant,
+            "graph": resources |where type == 'microsoft.network/virtualhubs' |extend addressSpace = properties.addressPrefix |extend compliant= (toint(substring(addressSpace, indexof(addressSpace, '/') + 1)) < 23) |distinct id, compliant,
             "link": "https://learn.microsoft.com/azure/virtual-wan/virtual-wan-faq#what-is-the-recommended-hub-address-space-during-hub-creation",
             "training": "https://learn.microsoft.com/training/modules/introduction-azure-virtual-wan/"
         },

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1837,7 +1837,7 @@
             "guid": "9c75dfef-573c-461c-a698-68598595581a",
             "id": "D10.09",
             "severity": "High",
-            "graph": resources | where type == 'microsoft.network/virtualhubs' | extend addressSpace = (properties.addressPrefix) | extend compliant= (toint(substring(addressSpace, indexof(addressSpace, "/") + 1)) < 23) | distinct id, compliant,
+            "graph": resources | where type == 'microsoft.network/virtualhubs' | extend addressSpace = (properties.addressPrefix) | extend compliant= (toint(substring(addressSpace, indexof(addressSpace, '/') + 1)) < 23) | distinct id, compliant,
             "link": "https://learn.microsoft.com/azure/virtual-wan/virtual-wan-faq#what-is-the-recommended-hub-address-space-during-hub-creation",
             "training": "https://learn.microsoft.com/training/modules/introduction-azure-virtual-wan/"
         },

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1837,7 +1837,7 @@
             "guid": "9c75dfef-573c-461c-a698-68598595581a",
             "id": "D10.09",
             "severity": "High",
-            "graph": "resources | where type == 'microsoft.network/virtualhubs' | extend addressSpace = properties.addressPrefix | extend compliant= (toint(substring(addressSpace, indexof(addressSpace, '/') + 1)) < 23) | distinct name, id, compliant",
+            "graph": "resources | where type =~ 'microsoft.network/virtualhubs' | extend addressSpace = properties.addressPrefix | extend compliant= (toint(substring(addressSpace, indexof(addressSpace, '/') + 1)) < 23) | distinct name, id, compliant",
             "link": "https://learn.microsoft.com/azure/virtual-wan/virtual-wan-faq#what-is-the-recommended-hub-address-space-during-hub-creation",
             "training": "https://learn.microsoft.com/training/modules/introduction-azure-virtual-wan/"
         },

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1837,7 +1837,7 @@
             "guid": "9c75dfef-573c-461c-a698-68598595581a",
             "id": "D10.09",
             "severity": "High",
-            "graph": resources |where type == 'microsoft.network/virtualhubs' |extend addressSpace = properties.addressPrefix |extend compliant= (toint(substring(addressSpace, indexof(addressSpace, '/') + 1)) < 23) |distinct id, compliant,
+            "graph": resources | where type == 'microsoft.network/virtualhubs' | extend addressSpace = properties.addressPrefix | extend compliant= (toint(substring(addressSpace, indexof(addressSpace, '/') + 1)) < 23) | distinct name, id, compliant,
             "link": "https://learn.microsoft.com/azure/virtual-wan/virtual-wan-faq#what-is-the-recommended-hub-address-space-during-hub-creation",
             "training": "https://learn.microsoft.com/training/modules/introduction-azure-virtual-wan/"
         },

--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -1837,7 +1837,7 @@
             "guid": "9c75dfef-573c-461c-a698-68598595581a",
             "id": "D10.09",
             "severity": "High",
-            "graph": resources | where type == 'microsoft.network/virtualhubs' | extend addressSpace = properties.addressPrefix | extend compliant= (toint(substring(addressSpace, indexof(addressSpace, '/') + 1)) < 23) | distinct name, id, compliant,
+            "graph": "resources | where type == 'microsoft.network/virtualhubs' | extend addressSpace = properties.addressPrefix | extend compliant= (toint(substring(addressSpace, indexof(addressSpace, '/') + 1)) < 23) | distinct name, id, compliant",
             "link": "https://learn.microsoft.com/azure/virtual-wan/virtual-wan-faq#what-is-the-recommended-hub-address-space-during-hub-creation",
             "training": "https://learn.microsoft.com/training/modules/introduction-azure-virtual-wan/"
         },


### PR DESCRIPTION
added query

## Description
Added ARG query for: 
**D10.09	Network Topology and Connectivity	Virtual WAN	Reliability	Assign at least a /23 prefix to virtual hubs to ensure enough IP space is available.**



## Related Issue
Link to any related issues or discussions here. This helps reviewers understand the context and the need for your changes.

<!-- Please follow this checklist and put an x in each box like this: [x]. -->
## Checklist

- [x] I've tested my changes to ensure they are ready for review.
- [x] I've read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the documentation (if applicable).
- [x] Resource Graph queries have been included (and tested) for recommendations where ever possible[^note].
- [ ] Resource Graph queries have NOT been included (please explain below).



## Additional Information
Is there any additional context, screenshots, or considerations that might help in the review process? Please include them here.
N/A

## Reviewer Notes
Is there a specific area you’d like feedback on? Please highlight it here. We're here to help and learn together! 💡
N/A

[^note]:
    Details on how to add Azure Resource Graph queries to recommendations can be found [here](../blob/main/CONTRIBUTING.md#1-adding-or-modifying-resource-graph-queries).
