### PR TITLE
Removed arg query and added the right AppGW doc as it was pointing to AFD WAF query and doc from item ID: A01.40 in network_appdelivery_checklist.en.json

### DIFF
--- a/checklists/network_appdelivery_checklist.en.json
+++ b/checklists/network_appdelivery_checklist.en.json
@@ -189,7 +189,7 @@
         {
             "category": "Network Topology and Connectivity",
             "subcategory": "App Gateway",
-            "text": "Enable request body inspection feature enabled in Azure Application Gateway WAF policy.",
+            "text": "Ensure if request body inspection feature is enabled in Azure Application Gateway WAF policy.",
             "waf": "Security",
             "service": "App Gateway",
             "guid": "8ea8e0d4-84e8-4b33-aeab-493f6391b4d6",
@@ -220,8 +220,7 @@
             "id": "A01.40",
             "ammp": true,
             "severity": "High",
-            "graph": "resources | where type == 'microsoft.network/frontdoorwebapplicationfirewallpolicies' | project policyName=name, policyId=id,policySku=sku.name, links=properties.securityPolicyLinks, enabledState=properties.policySettings.enabledState, mode=properties.policySettings.mode | mvexpand links | extend securityPolicy=links.id | extend securityPolicyParts=split(securityPolicy, '/') | extend profileId=strcat_array(array_slice(securityPolicyParts, 0, -3), '/') | project id=profileId, compliant=((enabledState=='Enabled') and (mode=='Prevention')), enabledState, mode",
-            "link": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-policy-settings"
+            "link": "https://learn.microsoft.com/azure/web-application-firewall/ag/policy-overview?source=recommendations"
         },
         {
             "category": "Network Topology and Connectivity",


### PR DESCRIPTION
removed arg query and added the learn more link as it was pointing to AFD WAF query and learn more link for AFD to item ID: A01.40 in network_appdelivery_checklist.en.json

## Description
Removed AFD query and added App GW WAF learn more link

## Related Issue
Link to any related issues or discussions here. This helps reviewers understand the context and the need for your changes.

<!-- Please follow this checklist and put an x in each box like this: [x]. -->
## Checklist

- [x] I've tested my changes to ensure they are ready for review.
- [x] I've read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the documentation (if applicable).
- [ ] Resource Graph queries have been included (and tested) for recommendations where ever possible[^note].
- [x] Resource Graph queries have NOT been included (please explain below).



## Additional Information
Is there any additional context, screenshots, or considerations that might help in the review process? Please include them here.

## Reviewer Notes
Is there a specific area you’d like feedback on? Please highlight it here. We're here to help and learn together! 💡

[^note]:
    Details on how to add Azure Resource Graph queries to recommendations can be found [here](../blob/main/CONTRIBUTING.md#1-adding-or-modifying-resource-graph-queries).
