### PR TITLE
added graph query to G02.08

### DIFF
--- a/checklists/alz_checklist.en.json
+++ b/checklists/alz_checklist.en.json
@@ -2422,6 +2422,7 @@
             "guid": "cdb3751a-b2ab-413a-ba6e-55d7d8a2adb1",
             "id": "G02.07",
             "severity": "Medium",
+            "graph" : "Resources | where type =~ 'microsoft.keyvault/vaults'  | extend properties = parse_json(properties)  | project id, name, location, firewallEnabled = properties.networkAcls.defaultAction, privateEndpointConnections = properties.privateEndpointConnections  | extend compliant = iff(firewallEnabled == 'Deny' or array_length(privateEndpointConnections) > 0, 1, 0)  | where compliant == 1  | project id, compliant",
             "link": "https://learn.microsoft.com/azure/key-vault/general/best-practices",
             "training": "https://learn.microsoft.com/training/modules/design-implement-private-access-to-azure-services/"
         },


### PR DESCRIPTION
## Description
addedAzure Resource Graph query that checks for key vaults with firewalls and virtual network service endpoints or private endpoints enabled, you can use the following query:

## Related Issue
N/A

<!-- Please follow this checklist and put an x in each box like this: [x]. -->
## Checklist

- [x] I've tested my changes to ensure they are ready for review.
- [x] I've read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the documentation (if applicable).
- [x] Resource Graph queries have been included (and tested) for recommendations where ever possible[^note].
- [ ] Resource Graph queries have NOT been included (please explain below).


## Additional Information
Is there any additional context, screenshots, or considerations that might help in the review process? Please include them here.

## Reviewer Notes
Is there a specific area you’d like feedback on? Please highlight it here. We're here to help and learn together! 💡

[^note]:
    Details on how to add Azure Resource Graph queries to recommendations can be found [here](../blob/main/CONTRIBUTING.md#1-adding-or-modifying-resource-graph-queries).
