### PR TITLE
Added comma to the end of ARG query line and also added compliant check to the ARG query - A01.38 in network_appdelivery_checklist.en.json

### DIFF
--- a/checklists/network_appdelivery_checklist.en.json
+++ b/checklists/network_appdelivery_checklist.en.json
@@ -196,7 +196,7 @@
             "id": "A01.38",
             "ammp": true,
             "severity": "High",
-            "graph": "resources | where type == 'microsoft.network/applicationgatewaywebapplicationfirewallpolicies' | extend compliant = (properties['policySettings']['requestBodyCheck'] == "true" and properties['policySettings']['state'] == "Enabled") | distinct id, name, compliant",
+            "graph": "resources | where type =~ 'microsoft.network/applicationgatewaywebapplicationfirewallpolicies' | extend compliant = (properties['policySettings']['requestBodyCheck'] == 'true' and properties['policySettings']['state'] =~ 'Enabled') | distinct id, name, compliant",
             "link": "https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-request-size-limits#request-body-inspection"
         },
         {

--- a/checklists/network_appdelivery_checklist.en.json
+++ b/checklists/network_appdelivery_checklist.en.json
@@ -196,6 +196,7 @@
             "id": "A01.38",
             "ammp": true,
             "severity": "High",
+            "graph": "resources | where type == 'microsoft.network/applicationgatewaywebapplicationfirewallpolicies' | extend compliant = (properties['policySettings']['requestBodyCheck'] == "true" and properties['policySettings']['state'] == "Enabled") | distinct id, name, compliant",
             "link": "https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-request-size-limits#request-body-inspection"
         },
         {


### PR DESCRIPTION


## Description
Added comma to the end of ARG query line and also added compliant tag check to the ARG query - A01.38.

## Related Issue
Link to any related issues or discussions here. This helps reviewers understand the context and the need for your changes.

<!-- Please follow this checklist and put an x in each box like this: [x]. -->
## Checklist

- [x] I've tested my changes to ensure they are ready for review.
- [x] I've read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the documentation (if applicable).
- [x] Resource Graph queries have been included (and tested) for recommendations where ever possible[^note].
- [ ] Resource Graph queries have NOT been included (please explain below).



## Additional Information
Is there any additional context, screenshots, or considerations that might help in the review process? Please include them here.

## Reviewer Notes
Is there a specific area you’d like feedback on? Please highlight it here. We're here to help and learn together! 💡

[^note]:
    Details on how to add Azure Resource Graph queries to recommendations can be found [here](../blob/main/CONTRIBUTING.md#1-adding-or-modifying-resource-graph-queries).
